### PR TITLE
lora-serialization decoder: allow selection of sensors via attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,21 @@ Decodes messages which contain 5 measurements of all sensors of the senseBox:hom
 The correct sensorIds are matched via their titles. Decoding matches the [dragino senseBox:home arduino sketch](https://github.com/sensebox/random-sketches/blob/master/lora/dragino/dragino.ino).
 
 ### `lora-serialization`
-Allows decoding of messages, which were encoded with the [`lora-serialization` library](https://github.com/thesolarnomad/lora-serialization).
-The sub-profiles `temperature`, `humidity`, `uint8`, `uint16` are supported, and matched to a sensor via it's ID. The following config allows decoding of measurements of a sensor like DHT22:
+Allows decoding of messages which were encoded with the [`lora-serialization` library](https://github.com/thesolarnomad/lora-serialization).
+The sub-profiles `temperature`, `humidity`, `uint8`, `uint16` are supported, and matched to a sensor via it's `_id`, `sensorType`, `unit`, or `title` properties.
+For each sensor one or more matchings may be defined as `sensor_id`, `sensor_title`, `sensor_type`, `sensor_unit`. If one property matches a sensor, the other properties are discarded.
+
+The following example config allows decoding of measurements of a 3 sensors:
 ```js
 ttn: {
   profile: 'lora-serialization',
   decodeOptions: [
-    { sensor_id: '588876b67dd004f79259bd8a', decoder: 'temperature' },
-    { sensor_id: '588876b67dd004f79259bd8b', decoder: 'humidity' }
+    { sensor_unit: '°C', decoder: 'temperature' },
+    { sensor_id: '588876b67dd004f79259bd8b', decoder: 'humidity' },
+    { sensor_type: 'TSL45315', sensor_title: 'Beleuchtungsstärke', decoder: 'uint16' }
   ]
 }
 ```
-
-TODO: support `unixtime` for measurement timestamps
 
 ### `debug`
 Simple decoder which decodes a given number of bytes to integer values. Requires a config like
@@ -44,6 +46,7 @@ where the measurements are applied to the boxes sensors in the order of `box.sen
 ### `json`
 It's also possible to add measurements which already have been decoded by a [TTN payload function](https://www.thethingsnetwork.org/docs/devices/uno/quick-start.html#monitor--decode-messages).
 The property `payload_fields` has to contain JSON in the [format accepted by the openSenseMap-API](https://docs.opensensemap.org/#api-Measurements-postNewMeasurements).
+This is the case, if the TTN application has a *Payload Function* defined.
 
 ## docs
 See `./docs/` or [sensebox.github.io/ttn-osem-application](https://sensebox.github.io/ttn-osem-application).

--- a/lib/decoding/helpers.js
+++ b/lib/decoding/helpers.js
@@ -21,16 +21,22 @@ const bytesToInt = function bytesToInt (bytes) {
 };
 
 /**
- * Matches the _ids of a set of sensors to a given set of options.
+ * Matches the _ids of a set of sensors to a given set of properties.
  * @param {Array} sensors - Set of sensors as specified in Box.sensors
- * @param {Object} sensorMatchings - defines a set of allowed values for each property
- * @param {String} [sensorProp=title] - Property on which the sensorMatchings are tested
- * @return {Object} Key-value pairs for the input property name of sensorMatchings and
- *         the matched sensorIds. If a matching was not found, the key is not included.
+ * @param {Object} sensorMatchings - defines a set of allowed values for one
+ *        or more properties. Once a property matches, the others are ignored.
+ * @return {Object} Key-value pairs for each property of sensorMatchings and
+ *         the matched sensorIds. If a match was not found, the key is not included.
  * @example <caption>sensorMatchings</caption>
  * {
- *   humidity: ['rel. luftfeuchte', 'luftfeuchtigkeit', 'humidity'],
- *   pressure: ['luftdruck', 'druck', 'pressure', 'air pressure'],
+ *   humidity: {
+ *     title: ['rel. luftfeuchte', 'luftfeuchtigkeit', 'humidity'],
+ *     type: ['HDC1008']
+ *   },
+ *   pressure: {
+ *     title: ['luftdruck', 'druck', 'pressure', 'air pressure'],
+ *     unit: ['°C', '°F']
+ *   }
  * }
  * @example <caption>result</caption>
  * {
@@ -38,21 +44,36 @@ const bytesToInt = function bytesToInt (bytes) {
  *   pressure: '588876b67dd004f79259bd8b'
  * }
  */
-const findSensorIds = function findSensorIds (sensors, sensorMatchings, sensorProp = 'title') {
+const findSensorIds = function findSensorIds (sensors, sensorMatchings) {
   const sensorMap = {}, sensorsCopy = sensors.slice();
 
+  // for each sensorId to find
   for (const phenomenon in sensorMatchings) {
-    const aliases = sensorMatchings[phenomenon];
-    for (let i = 0; i < sensorsCopy.length; i++) {
-      if (!sensorsCopy[i][sensorProp]) {
-        continue;
+
+    // for each sensor variable to look up
+    for (const sensorProp in sensorMatchings[phenomenon]) {
+
+      const aliases = sensorMatchings[phenomenon][sensorProp].map(a => a.toLowerCase());
+      let foundIt = false;
+
+      // for each unmatched sensor
+      for (let i = 0; i < sensorsCopy.length; i++) {
+        if (!sensorsCopy[i][sensorProp]) {
+          continue;
+        }
+
+        const prop = sensorsCopy[i][sensorProp].toString().toLowerCase();
+
+        if (aliases.includes(prop)) {
+          sensorMap[phenomenon] = sensorsCopy[i]._id.toString();
+          sensorsCopy.splice(i, 1);
+          foundIt = true;
+          break;
+        }
       }
 
-      const prop = sensorsCopy[i][sensorProp].toString().toLowerCase();
-
-      if (aliases.includes(prop)) {
-        sensorMap[phenomenon] = sensorsCopy[i]._id.toString();
-        sensorsCopy.splice(i, 1);
+      // don't check the other properties, if one did match
+      if (foundIt) {
         break;
       }
     }

--- a/lib/decoding/lora-serialization.js
+++ b/lib/decoding/lora-serialization.js
@@ -22,25 +22,46 @@ const loraSerialization = require('lora-serialization').decoder,
  *     sensor_id: '588876b67dd004f79259bd8a',
  *     decoder: 'temperature' // one of [temperature, humidity, uint8, uint16]
  *   }, {
- *     sensor_id: '588876b67dd004f79259bd8b',
- *     decoder: 'uint8'
+ *     // sensor_type, sensor_title, sensor_unit is allowed as well
+ *     sensor_type: '588876b67dd004f79259bd8b',
+ *     decoder: 'VEML6070'
  *   }]
  * }
  */
 const createBufferTransformer = function createBufferTransformer (box) {
   const byteMask = box.integrations.ttn.decodeOptions,
-    bufferTransf = [];
+    bufferTransf = [],
+    sensorMatchings = [];
 
   if (!byteMask || byteMask.constructor !== Array) {
     throw new Error('profile \'lora-serialization\' requires valid decodeOptions');
   }
 
-  const idMatchings = [];
-  for (const x of byteMask) {
-    idMatchings[x.sensor_id] = x.sensor_id;
+  // construct sensorMatchings to find the correct sensorIds
+  for (const el of byteMask) {
+    const match = {};
+    if (el.sensor_id) {
+      match['_id'] = [el.sensor_id];
+    }
+    if (el.sensor_title) {
+      match['title'] = [el.sensor_title];
+    }
+    if (el.sensor_type) {
+      match['sensorType'] = [el.sensor_type];
+    }
+    if (el.sensor_unit) {
+      match['unit'] = [el.sensor_unit];
+    }
+
+    if (Object.keys(match).length === 0) {
+      throw new Error('invalid decodeOptions. requires at least one of [sensor_id, sensor_title, sensor_type]');
+    }
+    sensorMatchings.push(match);
   }
 
-  if (Object.keys(findSensorIds(box.sensors, idMatchings, '_id')).length !== byteMask.length) {
+  const sensorIds = findSensorIds(box.sensors, sensorMatchings);
+
+  if (Object.keys(sensorIds).length !== byteMask.length) {
     throw new Error('box does not contain sensors mentioned in byteMask');
   }
 
@@ -53,7 +74,7 @@ const createBufferTransformer = function createBufferTransformer (box) {
     }
 
     bufferTransf.push({
-      sensorId,
+      sensorId: sensorIds[i][i],
       transformer,
       bytes: transformer.BYTES,
     });

--- a/lib/decoding/lora-serialization.js
+++ b/lib/decoding/lora-serialization.js
@@ -44,8 +44,6 @@ const createBufferTransformer = function createBufferTransformer (box) {
     throw new Error('box does not contain sensors mentioned in byteMask');
   }
 
-  // TODO: check if sensors exist. maybe DB validation?
-
   for (let i = 0; i < byteMask.length; i++) {
     const sensorId = byteMask[i].sensor_id,
       transformer = loraSerialization[byteMask[i].decoder];

--- a/lib/decoding/sensebox_home.js
+++ b/lib/decoding/sensebox_home.js
@@ -12,11 +12,21 @@ const { bytesToInt, findSensorIds } = require('./helpers');
 
 // alternative titles recognized for the sensors
 const sensorMatchings = {
-  temperature: ['temperatur', 'temperature'],
-  humidity: ['rel. luftfeuchte', 'luftfeuchtigkeit', 'humidity'],
-  pressure: ['luftdruck', 'druck', 'pressure', 'air pressure'],
-  lightintensity: ['licht', 'helligkeit', 'beleuchtungsstärke', 'einstrahlung', 'light', 'light intensity'],
-  uvlight: ['uv', 'uv-a', 'uv-intensität', 'uv-intensity']
+  temperature: {
+    title: ['temperatur', 'temperature'],
+  },
+  humidity: {
+    title: ['rel. luftfeuchte', 'luftfeuchtigkeit', 'humidity']
+  },
+  pressure: {
+    title: ['luftdruck', 'druck', 'pressure', 'air pressure']
+  },
+  lightintensity: {
+    title: ['licht', 'helligkeit', 'beleuchtungsstärke', 'einstrahlung', 'light', 'light intensity']
+  },
+  uvlight: {
+    title: ['uv', 'uv-a', 'uv-intensität', 'uv-intensity']
+  }
 };
 
 /**

--- a/lib/routes/v1.1.js
+++ b/lib/routes/v1.1.js
@@ -112,7 +112,6 @@ router.post('/', (req, res) => {
 
   // store measurements in DB
   .then(measurements => {
-    console.log(measurements);
     return req.box.saveMeasurementsArray(measurements)
       .catch(msg => Promise.reject({ code: 501, msg }));
   })

--- a/test/00decoder.js
+++ b/test/00decoder.js
@@ -217,6 +217,16 @@ describe('decoder', () => {
         .to.be.rejectedWith('box does not contain sensors mentioned in byteMask');
     });
 
+    it('should reject a box with invalid decodeOptions', () => {
+      p.box.integrations.ttn.decodeOptions.map(el => {
+        delete el.sensor_id;
+        return el;
+      });
+
+      return expect(decoder.decodeBase64(p.payloads.base64, p.box))
+        .to.be.rejectedWith('invalid decodeOptions. requires at least one of [sensor_id, sensor_title, sensor_type]');
+    });
+
     it('should reject a box with missing byteMask', () => {
       delete p.box.integrations.ttn.decodeOptions;
 

--- a/test/data/ttnBox_loraserialization.json
+++ b/test/data/ttnBox_loraserialization.json
@@ -11,10 +11,10 @@
         "sensor_id": "588876b67dd004f79259bd8e",
         "decoder": "temperature"
       }, {
-        "sensor_id": "588876b67dd004f79259bd8d",
+        "sensor_title": "rel. Luftfeuchte",
         "decoder": "humidity"
       }, {
-        "sensor_id": "588876b67dd004f79259bd8a",
+        "sensor_type": "VEML6070",
         "decoder": "uint16"
       }]
     }


### PR DESCRIPTION
Previously sensors had to be selected via their `_id` field, which is unknown prior to box registration.
To simplify the configuration process, sensors may now also be selected via their attributes
`sensor_title`, `sensor_type` and `sensor_unit`.

@ubergesundheit fyi